### PR TITLE
Feature/more supported modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ xpath-to-xml uses [semver](http://semver.org/) for its versioning convention.
 
 ## 1.x Series
 
+### 1.0.1
+
+Bugfixes:
+
+- EqualsExpr now correctly reports an error if unable to satisfy given case
+- NotEqualsExpr supports more cases now and also correctly reports an error
+- LessThatOrEquals and GreaterThanOrEquals are now supported (with fallback to EqualsExpr resolver) 
+
 ### 1.0.0 Initial Release
 
 Features:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Include an artifact with necessary model extension into your project:
 <dependency>
     <groupId>com.github.simy4</groupId>
     <artifactId>xpath-to-xml-dom</artifactId>
-    <version>1.0.0-RC2</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 ext {
     jUnitVersion = '4.12'
     mockitoVersion = '2.13.0'
-    assertjVersion = '2.8.0'
-    errorproneVersion = '2.1.3'
+    assertjVersion = '2.9.0'
+    errorproneVersion = '2.2.0'
     checkstyleVersion = '8.7'
 
     def buildTimeAndDate = new Date()

--- a/gradle/check-codecoverage.gradle
+++ b/gradle/check-codecoverage.gradle
@@ -6,8 +6,8 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.enabled = true
+        html.enabled = true
         html.destination file("${buildDir}/jacocoHtml")
     }
 }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/PutEffect.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/PutEffect.java
@@ -24,17 +24,18 @@ public class PutEffect implements Effect {
         expr.resolve(context).visit(new EagerVisitor<N>());
     }
 
-    private static final class EagerVisitor<N extends Node> extends AbstractViewVisitor<N> {
+    private static final class EagerVisitor<N extends Node> extends AbstractViewVisitor<N, Void> {
 
         @Override
         @SuppressWarnings("StatementWithEmptyBody")
-        public void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+        public Void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
             for (NodeView<N> ignored : nodeSet) { } // eagerly consume resolved iterable
+            return null;
         }
 
         @Override
-        protected void returnDefault(View<N> view) {
-            /* NO OP */
+        protected Void returnDefault(View<N> view) {
+            return null;
         }
 
     }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/PutValueEffect.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/PutValueEffect.java
@@ -27,7 +27,7 @@ public class PutValueEffect implements Effect {
         view.visit(new PutValueVisitor<N>(navigator, value));
     }
 
-    private static final class PutValueVisitor<N extends Node> extends AbstractViewVisitor<N> {
+    private static final class PutValueVisitor<N extends Node> extends AbstractViewVisitor<N, Void> {
 
         private final Navigator<N> navigator;
         private final String value;
@@ -38,14 +38,15 @@ public class PutValueEffect implements Effect {
         }
 
         @Override
-        public void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+        public Void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
             for (NodeView<N> node : nodeSet) {
                 navigator.setText(node.getNode(), value);
             }
+            return null;
         }
 
         @Override
-        protected void returnDefault(View<N> view) throws XmlBuilderException {
+        protected Void returnDefault(View<N> view) throws XmlBuilderException {
             throw new XmlBuilderException("Failed to put value into XML. Read-only view was resolved: " + view);
         }
 

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/RemoveEffect.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/effects/RemoveEffect.java
@@ -25,7 +25,7 @@ public class RemoveEffect implements Effect {
         view.visit(new RemoveVisitor<N>(navigator));
     }
 
-    private static final class RemoveVisitor<N extends Node> extends AbstractViewVisitor<N> {
+    private static final class RemoveVisitor<N extends Node> extends AbstractViewVisitor<N, Void> {
 
         private final Navigator<N> navigator;
 
@@ -34,16 +34,16 @@ public class RemoveEffect implements Effect {
         }
 
         @Override
-        public void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+        public Void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
             for (NodeView<N> node : nodeSet) {
                 navigator.remove(node.getNode());
             }
-            returnDefault(nodeSet);
+            return null;
         }
 
         @Override
-        protected void returnDefault(View<N> ignored) {
-            /* NO OP */
+        protected Void returnDefault(View<N> ignored) {
+            return null;
         }
 
     }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExpr.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExpr.java
@@ -15,10 +15,9 @@ public class GreaterThanOrEqualsExpr extends AbstractOperationExpr {
     @Override
     public <N extends Node> View<N> resolve(ViewContext<N> context, View<N> left, View<N> right)
             throws XmlBuilderException {
-        final boolean ge = 0 <= Double.compare(left.toNumber(), right.toNumber());
+        boolean ge = 0 <= Double.compare(left.toNumber(), right.toNumber());
         if (!ge && context.isGreedy() && !context.hasNext()) {
-            throw new XmlBuilderException("Can not apply a 'greater than or equals' operator "
-                    + "to: " + left + " and: " + right);
+            ge = left.visit(new EqualsExpr.EqualsVisitor<N>(context.getNavigator(), right));
         }
         return BooleanView.of(ge);
     }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/LessThanOrEqualsExpr.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/LessThanOrEqualsExpr.java
@@ -15,10 +15,9 @@ public class LessThanOrEqualsExpr extends AbstractOperationExpr {
     @Override
     public <N extends Node> View<N> resolve(ViewContext<N> context, View<N> left, View<N> right)
             throws XmlBuilderException {
-        final boolean le = 0 >= Double.compare(left.toNumber(), right.toNumber());
+        boolean le = 0 >= Double.compare(left.toNumber(), right.toNumber());
         if (!le && context.isGreedy() && !context.hasNext()) {
-            throw new XmlBuilderException("Can not apply a 'less than or equals' operator "
-                    + "to: " + left + " and: " + right);
+            le = left.visit(new EqualsExpr.EqualsVisitor<N>(context.getNavigator(), right));
         }
         return BooleanView.of(le);
     }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/NotEqualsExpr.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/expr/NotEqualsExpr.java
@@ -6,9 +6,14 @@ import com.github.simy4.xpath.navigator.Node;
 import com.github.simy4.xpath.view.AbstractViewVisitor;
 import com.github.simy4.xpath.view.BooleanView;
 import com.github.simy4.xpath.view.IterableNodeView;
+import com.github.simy4.xpath.view.LiteralView;
 import com.github.simy4.xpath.view.NodeView;
+import com.github.simy4.xpath.view.NumberView;
 import com.github.simy4.xpath.view.View;
 import com.github.simy4.xpath.view.ViewContext;
+import com.github.simy4.xpath.view.ViewVisitor;
+
+import java.util.Iterator;
 
 public class NotEqualsExpr extends AbstractOperationExpr {
 
@@ -19,12 +24,11 @@ public class NotEqualsExpr extends AbstractOperationExpr {
     @Override
     public <N extends Node> View<N> resolve(ViewContext<N> context, View<N> left, View<N> right)
             throws XmlBuilderException {
-        boolean eq = 0 == left.compareTo(right);
-        if (eq && context.isGreedy() && !context.hasNext()) {
-            left.visit(new ApplicationVisitor<N>(context.getNavigator(), right));
-            eq = false;
+        boolean ne = 0 != left.compareTo(right);
+        if (!ne && context.isGreedy() && !context.hasNext()) {
+            ne = left.visit(new NotEqualsVisitor<N>(context.getNavigator(), right));
         }
-        return BooleanView.of(!eq);
+        return BooleanView.of(ne);
     }
 
     @Override
@@ -32,26 +36,60 @@ public class NotEqualsExpr extends AbstractOperationExpr {
         return "!=";
     }
 
-    private static final class ApplicationVisitor<N extends Node> extends AbstractViewVisitor<N> {
+    private static final class NotEqualsVisitor<N extends Node> extends AbstractViewVisitor<N, Boolean> {
 
         private final Navigator<N> navigator;
         private final View<N> right;
 
-        private ApplicationVisitor(Navigator<N> navigator, View<N> right) {
+        private NotEqualsVisitor(Navigator<N> navigator, View<N> right) {
             this.navigator = navigator;
             this.right = right;
         }
 
         @Override
-        public void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
-            for (NodeView<N> node : nodeSet) {
-                navigator.setText(node.getNode(), Boolean.toString(!right.toBoolean()));
+        public Boolean visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+            final Iterator<NodeView<N>> iterator = nodeSet.iterator();
+            final View<N> negatedRight = right.visit(new ViewNegator<N>());
+            if (!iterator.hasNext() || right.toString().equals(negatedRight.toString())) {
+                throw new XmlBuilderException("Unable to satisfy not equals criteria for: " + right);
             }
+            while (iterator.hasNext()) {
+                navigator.setText(iterator.next().getNode(), negatedRight.toString());
+            }
+            return true;
         }
 
         @Override
-        protected void returnDefault(View<N> view) throws XmlBuilderException {
+        protected Boolean returnDefault(View<N> view) throws XmlBuilderException {
             throw new XmlBuilderException("Can not modify read-only node: " + view);
+        }
+
+    }
+
+    private static final class ViewNegator<N extends Node> implements ViewVisitor<N, View<N>> {
+
+        @Override
+        public View<N> visit(BooleanView<N> bool) {
+            return BooleanView.of(!bool.toBoolean());
+        }
+
+        @Override
+        public View<N> visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+            final Iterator<NodeView<N>> iterator = nodeSet.iterator();
+            if (!iterator.hasNext()) {
+                throw new XmlBuilderException("Unable to satisfy not equals criteria for: " + nodeSet);
+            }
+            return new LiteralView<N>(new StringBuilder(iterator.next().toString()).reverse().toString());
+        }
+
+        @Override
+        public View<N> visit(LiteralView<N> literal) {
+            return new LiteralView<N>(new StringBuilder(literal.toString()).reverse().toString());
+        }
+
+        @Override
+        public View<N> visit(NumberView<N> number) {
+            return new NumberView<N>(-number.toNumber());
         }
 
     }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/AbstractViewVisitor.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/AbstractViewVisitor.java
@@ -3,28 +3,28 @@ package com.github.simy4.xpath.view;
 import com.github.simy4.xpath.XmlBuilderException;
 import com.github.simy4.xpath.navigator.Node;
 
-public abstract class AbstractViewVisitor<N extends Node> implements ViewVisitor<N> {
+public abstract class AbstractViewVisitor<N extends Node, T> implements ViewVisitor<N, T> {
 
     @Override
-    public void visit(BooleanView<N> bool) throws XmlBuilderException {
-        returnDefault(bool);
+    public T visit(BooleanView<N> bool) throws XmlBuilderException {
+        return returnDefault(bool);
     }
 
     @Override
-    public void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
-        returnDefault(nodeSet);
+    public T visit(IterableNodeView<N> nodeSet) throws XmlBuilderException {
+        return returnDefault(nodeSet);
     }
 
     @Override
-    public void visit(LiteralView<N> literal) throws XmlBuilderException {
-        returnDefault(literal);
+    public T visit(LiteralView<N> literal) throws XmlBuilderException {
+        return returnDefault(literal);
     }
 
     @Override
-    public void visit(NumberView<N> number) throws XmlBuilderException {
-        returnDefault(number);
+    public T visit(NumberView<N> number) throws XmlBuilderException {
+        return returnDefault(number);
     }
 
-    protected abstract void returnDefault(View<N> view) throws XmlBuilderException;
+    protected abstract T returnDefault(View<N> view) throws XmlBuilderException;
 
 }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/BooleanView.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/BooleanView.java
@@ -41,13 +41,13 @@ public final class BooleanView<N extends Node> implements View<N> {
     }
 
     @Override
-    public void visit(ViewVisitor<N> visitor) throws XmlBuilderException {
-        visitor.visit(this);
+    public <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException {
+        return visitor.visit(this);
     }
 
     @Override
     public boolean equals(Object o) {
-        return ((this == o || null != o) && o instanceof View) && bool == ((View<?>) o).toBoolean();
+        return this == o || (o instanceof View && bool == ((View<?>) o).toBoolean());
     }
 
     @Override

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/LiteralView.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/LiteralView.java
@@ -36,13 +36,13 @@ public final class LiteralView<N extends Node> implements View<N> {
     }
 
     @Override
-    public void visit(ViewVisitor<N> visitor) throws XmlBuilderException {
-        visitor.visit(this);
+    public <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException {
+        return visitor.visit(this);
     }
 
     @Override
     public boolean equals(Object o) {
-        return ((this == o || null != o) && o instanceof View) && literal.equals(o.toString());
+        return this == o || (o instanceof View && literal.equals(o.toString()));
     }
 
     @Override

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NodeSetView.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NodeSetView.java
@@ -76,8 +76,8 @@ public final class NodeSetView<N extends Node> implements IterableNodeView<N> {
     }
 
     @Override
-    public void visit(ViewVisitor<N> visitor) throws XmlBuilderException {
-        visitor.visit(this);
+    public <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException {
+        return visitor.visit(this);
     }
 
     @Override
@@ -125,7 +125,7 @@ public final class NodeSetView<N extends Node> implements IterableNodeView<N> {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof View)) {
+        if (!(o instanceof View)) {
             return false;
         }
 

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NodeView.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NodeView.java
@@ -42,8 +42,8 @@ public final class NodeView<N extends Node> implements IterableNodeView<N> {
     }
 
     @Override
-    public void visit(ViewVisitor<N> visitor) throws XmlBuilderException {
-        visitor.visit(this);
+    public <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException {
+        return visitor.visit(this);
     }
 
     @Override
@@ -73,7 +73,7 @@ public final class NodeView<N extends Node> implements IterableNodeView<N> {
 
     @Override
     public boolean equals(Object o) {
-        return ((this == o || null != o) && o instanceof View) && toString().equals(o.toString());
+        return this == o || (o instanceof View && toString().equals(o.toString()));
     }
 
     @Override

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NumberView.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/NumberView.java
@@ -32,13 +32,13 @@ public final class NumberView<N extends Node> implements View<N> {
     }
 
     @Override
-    public void visit(ViewVisitor<N> visitor) throws XmlBuilderException {
-        visitor.visit(this);
+    public <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException {
+        return visitor.visit(this);
     }
 
     @Override
     public boolean equals(Object o) {
-        return ((this == o || null != o) && o instanceof View) && 0 == Double.compare(number, ((View<?>) o).toNumber());
+        return this == o || (o instanceof View && 0 == Double.compare(number, ((View<?>) o).toNumber()));
     }
 
     @Override

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/View.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/View.java
@@ -38,8 +38,10 @@ public interface View<N extends Node> extends Comparable<View<N>> {
      * Visits current XML element.
      *
      * @param visitor XML element visitor
+     * @param <T>     type of return value
+     * @return visitor result
      * @throws XmlBuilderException if error occur during XML model modification
      */
-    void visit(ViewVisitor<N> visitor) throws XmlBuilderException;
+    <T> T visit(ViewVisitor<N, T> visitor) throws XmlBuilderException;
 
 }

--- a/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/ViewVisitor.java
+++ b/xpath-to-xml-core/src/main/java/com/github/simy4/xpath/view/ViewVisitor.java
@@ -10,14 +10,14 @@ import com.github.simy4.xpath.navigator.Node;
  * @author Alex Simkin
  * @since 1.0
  */
-public interface ViewVisitor<N extends Node> {
+public interface ViewVisitor<N extends Node, T> {
 
-    void visit(BooleanView<N> bool) throws XmlBuilderException;
+    T visit(BooleanView<N> bool) throws XmlBuilderException;
 
-    void visit(IterableNodeView<N> nodeSet) throws XmlBuilderException;
+    T visit(IterableNodeView<N> nodeSet) throws XmlBuilderException;
 
-    void visit(LiteralView<N> literal) throws XmlBuilderException;
+    T visit(LiteralView<N> literal) throws XmlBuilderException;
 
-    void visit(NumberView<N> number) throws XmlBuilderException;
+    T visit(NumberView<N> number) throws XmlBuilderException;
 
 }

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/EqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/EqualsExprTest.java
@@ -4,8 +4,8 @@ import com.github.simy4.xpath.XmlBuilderException;
 import com.github.simy4.xpath.navigator.Navigator;
 import com.github.simy4.xpath.util.TestNode;
 import com.github.simy4.xpath.view.BooleanView;
+import com.github.simy4.xpath.view.IterableNodeView;
 import com.github.simy4.xpath.view.LiteralView;
-import com.github.simy4.xpath.view.NodeSetView;
 import com.github.simy4.xpath.view.NodeView;
 import com.github.simy4.xpath.view.NumberView;
 import com.github.simy4.xpath.view.View;
@@ -96,8 +96,7 @@ public class EqualsExprTest {
     public void shouldApplyRightViewToLeftViewWhenShouldCreate(@FromDataPoints("eq left") View<TestNode> left,
                                                                @FromDataPoints("eq right") View<TestNode> right) {
         // given
-        if (!(left instanceof NodeView)
-                && (!(left instanceof NodeSetView) || !(((NodeSetView) left).iterator().next() instanceof NodeView))) {
+        if (!(left instanceof IterableNodeView && ((IterableNodeView<TestNode>) left).iterator().hasNext())) {
             expectedException.expect(XmlBuilderException.class);
         }
         when(leftExpr.resolve(any(ViewContext.class))).thenReturn(left);

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExprTest.java
@@ -4,6 +4,7 @@ import com.github.simy4.xpath.XmlBuilderException;
 import com.github.simy4.xpath.navigator.Navigator;
 import com.github.simy4.xpath.util.TestNode;
 import com.github.simy4.xpath.view.BooleanView;
+import com.github.simy4.xpath.view.IterableNodeView;
 import com.github.simy4.xpath.view.LiteralView;
 import com.github.simy4.xpath.view.NodeView;
 import com.github.simy4.xpath.view.NumberView;
@@ -98,10 +99,12 @@ public class GreaterThanOrEqualsExprTest {
     }
 
     @Theory
-    public void shouldThrowWhenResolveToFalseAndShouldCreate(@FromDataPoints("less") View<TestNode> less,
-                                                             @FromDataPoints("greater") View<TestNode> greater) {
+    public void shouldApplyRightViewToLeftViewWhenShouldCreate(@FromDataPoints("less") View<TestNode> less,
+                                                               @FromDataPoints("greater") View<TestNode> greater) {
         // given
-        expectedException.expect(XmlBuilderException.class);
+        if (!(less instanceof IterableNodeView && ((IterableNodeView<TestNode>) less).iterator().hasNext())) {
+            expectedException.expect(XmlBuilderException.class);
+        }
         when(leftExpr.resolve(any(ViewContext.class))).thenReturn(less);
         when(rightExpr.resolve(any(ViewContext.class))).thenReturn(greater);
         ViewContext<TestNode> context = new ViewContext<TestNode>(navigator, parentNode, true);

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/GreaterThanOrEqualsExprTest.java
@@ -25,6 +25,8 @@ import org.mockito.junit.MockitoRule;
 import static com.github.simy4.xpath.util.TestNode.node;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(Theories.class)
@@ -110,7 +112,11 @@ public class GreaterThanOrEqualsExprTest {
         ViewContext<TestNode> context = new ViewContext<TestNode>(navigator, parentNode, true);
 
         // when
-        new GreaterThanOrEqualsExpr(leftExpr, rightExpr).resolve(context, less, greater);
+        View<TestNode> result = new GreaterThanOrEqualsExpr(leftExpr, rightExpr).resolve(context, less, greater);
+
+        // then
+        assertThat(result).isEqualTo(BooleanView.of(true));
+        verify(navigator).setText(any(TestNode.class), eq(greater.toString()));
     }
 
     @Test

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/LessThanOrEqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/LessThanOrEqualsExprTest.java
@@ -25,6 +25,8 @@ import org.mockito.junit.MockitoRule;
 import static com.github.simy4.xpath.util.TestNode.node;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(Theories.class)
@@ -110,7 +112,11 @@ public class LessThanOrEqualsExprTest {
         ViewContext<TestNode> context = new ViewContext<TestNode>(navigator, parentNode, true);
 
         // when
-        new LessThanOrEqualsExpr(leftExpr, rightExpr).resolve(context);
+        View<TestNode> result = new LessThanOrEqualsExpr(leftExpr, rightExpr).resolve(context);
+
+        // then
+        assertThat(result).isEqualTo(BooleanView.of(true));
+        verify(navigator).setText(any(TestNode.class), eq(less.toString()));
     }
 
     @Test

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/LessThanOrEqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/LessThanOrEqualsExprTest.java
@@ -4,6 +4,7 @@ import com.github.simy4.xpath.XmlBuilderException;
 import com.github.simy4.xpath.navigator.Navigator;
 import com.github.simy4.xpath.util.TestNode;
 import com.github.simy4.xpath.view.BooleanView;
+import com.github.simy4.xpath.view.IterableNodeView;
 import com.github.simy4.xpath.view.LiteralView;
 import com.github.simy4.xpath.view.NodeView;
 import com.github.simy4.xpath.view.NumberView;
@@ -98,10 +99,12 @@ public class LessThanOrEqualsExprTest {
     }
 
     @Theory
-    public void shouldThrowWhenResolveToFalseAndShouldCreate(@FromDataPoints("less") View<TestNode> less,
-                                                             @FromDataPoints("greater") View<TestNode> greater) {
+    public void shouldApplyRightViewToLeftViewWhenShouldCreate(@FromDataPoints("less") View<TestNode> less,
+                                                               @FromDataPoints("greater") View<TestNode> greater) {
         // given
-        expectedException.expect(XmlBuilderException.class);
+        if (!(greater instanceof IterableNodeView && ((IterableNodeView<TestNode>) greater).iterator().hasNext())) {
+            expectedException.expect(XmlBuilderException.class);
+        }
         when(leftExpr.resolve(any(ViewContext.class))).thenReturn(greater);
         when(rightExpr.resolve(any(ViewContext.class))).thenReturn(less);
         ViewContext<TestNode> context = new ViewContext<TestNode>(navigator, parentNode, true);

--- a/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/NotEqualsExprTest.java
+++ b/xpath-to-xml-core/src/test/java/com/github/simy4/xpath/expr/NotEqualsExprTest.java
@@ -4,8 +4,8 @@ import com.github.simy4.xpath.XmlBuilderException;
 import com.github.simy4.xpath.navigator.Navigator;
 import com.github.simy4.xpath.util.TestNode;
 import com.github.simy4.xpath.view.BooleanView;
+import com.github.simy4.xpath.view.IterableNodeView;
 import com.github.simy4.xpath.view.LiteralView;
-import com.github.simy4.xpath.view.NodeSetView;
 import com.github.simy4.xpath.view.NodeView;
 import com.github.simy4.xpath.view.NumberView;
 import com.github.simy4.xpath.view.View;
@@ -18,6 +18,7 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -26,7 +27,6 @@ import static com.github.simy4.xpath.util.TestNode.node;
 import static com.github.simy4.xpath.view.NodeSetView.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,8 +96,7 @@ public class NotEqualsExprTest {
     public void shouldApplyRightViewToLeftViewWhenShouldCreate(@FromDataPoints("ne left") View<TestNode> left,
                                                                @FromDataPoints("ne left") View<TestNode> right) {
         // given
-        if (!(left instanceof NodeView)
-                && (!(left instanceof NodeSetView) || !(((NodeSetView) left).iterator().next() instanceof NodeView))) {
+        if (!(left instanceof IterableNodeView && ((IterableNodeView<TestNode>) left).iterator().hasNext())) {
             expectedException.expect(XmlBuilderException.class);
         }
         when(leftExpr.resolve(any(ViewContext.class))).thenReturn(left);
@@ -109,7 +108,9 @@ public class NotEqualsExprTest {
 
         // then
         assertThat(result).isEqualTo(BooleanView.of(true));
-        verify(navigator).setText(any(TestNode.class), eq(Boolean.toString(!right.toBoolean())));
+        ArgumentCaptor<String> textCaptor = ArgumentCaptor.forClass(String.class);
+        verify(navigator).setText(any(TestNode.class), textCaptor.capture());
+        assertThat(textCaptor.getValue()).isNotEqualTo(right.toString());
     }
 
     @Test


### PR DESCRIPTION
NotEquals not propertly generate values based on right side expression type
Equals handle the case where left-side can be empty
LessThanOrEquals and GreaterThatOrEquals now generates value the same way Equals does